### PR TITLE
Show support for SonarQube 25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   [#39](https://github.com/green-code-initiative/creedengo-javascript/issues/39) Add rule `@creedengo/avoid-brightness-override` (GCI522)
 -   [#41](https://github.com/green-code-initiative/creedengo-javascript/pull/41) Add rule `@creedengo/no-torch` (GCI530)
--   Rename plugin to creedengo-javascript
--   Add support for SonarQube up to 10.7
+-   [#58](https://github.com/green-code-initiative/creedengo-javascript/pull/58) Add support for SonarQube up to 25.1
 
 ### Changed
 
+-   [#56](https://github.com/green-code-initiative/creedengo-javascript/issues/56) **BREAKING:** Rename plugin to creedengo-javascript
 -   [#44](https://github.com/green-code-initiative/creedengo-javascript/pull/44) Implement the rule GCI523 for React Native
 -   [#52](https://github.com/green-code-initiative/creedengo-javascript/pull/52) Remove trailing dots in Sonar rules descriptions
 -   Update Docker Compose configuration file to V2

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The standalone version of the ESLint plugin is available from [npmjs](https://np
 
 | Plugins Version | SonarQube version | ESLint version |
 | --------------- | ----------------- | -------------- |
-| 1.4.+, 1.5.+    | 9.9.+ LTA to 10.7 | 7+             |
+| 1.4.+, 1.5.+    | 9.9.+ LTA to 25.1 | 7+             |
 
 ## 🤝 Contribution
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: sonarqube_creedengo_javascript
 
 services:
   sonar:
-    image: sonarqube:10.7-community
+    image: sonarqube:25.1.0.102122-community
     container_name: sonar_creedengo_javascript
     ports:
       - "9000:9000"


### PR DESCRIPTION
### Support for Newer SonarQube Versions:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL14-R18): Added support for SonarQube up to version 25.1.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R51): Updated the supported SonarQube version range to include up to version 25.1.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L6-R6): Updated the SonarQube image to version 25.1.0.102122-community.

### Breaking Changes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL14-R18): Renamed the plugin to creedengo-javascript, marked as a breaking change.