### PR TITLE
Fix optional chaining for style attribute checks in ESLint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [#56](https://github.com/green-code-initiative/creedengo-javascript/issues/56) **BREAKING:** Rename plugin to creedengo-javascript
 -   [#44](https://github.com/green-code-initiative/creedengo-javascript/pull/44) Implement the rule GCI523 for React Native
 -   [#52](https://github.com/green-code-initiative/creedengo-javascript/pull/52) Remove trailing dots in Sonar rules descriptions
+-   [#62](https://github.com/green-code-initiative/creedengo-javascript/pull/62) Fix style attribute checks in GCI26 and GCI29
 -   Update Docker Compose configuration file to V2
 
 ### Deleted

--- a/eslint-plugin/lib/rules/avoid-css-animations.js
+++ b/eslint-plugin/lib/rules/avoid-css-animations.js
@@ -37,7 +37,7 @@ module.exports = {
     return {
       JSXOpeningElement(node) {
         const styleAttribute = node.attributes.find(
-          (attribute) => attribute.name.name === "style",
+          (attribute) => attribute.name?.name === "style",
         );
 
         if (styleAttribute?.value.expression) {

--- a/eslint-plugin/lib/rules/prefer-shorthand-css-notations.js
+++ b/eslint-plugin/lib/rules/prefer-shorthand-css-notations.js
@@ -84,7 +84,7 @@ module.exports = {
     return {
       JSXOpeningElement(node) {
         const styleAttribute = node.attributes.find(
-          (attr) => attr.name.name === "style",
+          (attr) => attr.name?.name === "style",
         );
         if (styleAttribute) {
           const nodePropertyNames =

--- a/eslint-plugin/tests/lib/rules/avoid-css-animations.js
+++ b/eslint-plugin/tests/lib/rules/avoid-css-animations.js
@@ -53,6 +53,8 @@ ruleTester.run("avoid-css-animations", rule, {
     `,
     `<div style={{ width: '100px', height: '100px' }}>Hello world</div>`,
     `<div style="border: 2px solid red">My red element</div>`,
+    // spread attributes should not throw an error (#49)
+    "<input {...inputProps} className={styles.input} onChange={handleChange}/>",
   ],
 
   invalid: [

--- a/eslint-plugin/tests/lib/rules/prefer-shorthand-css-notations.js
+++ b/eslint-plugin/tests/lib/rules/prefer-shorthand-css-notations.js
@@ -73,6 +73,8 @@ ruleTester.run("prefer-shorthand-css-notations", rule, {
       code: "<div style={{ animationName: 'example', animationDuration: '5s' }}/>",
       options: [{ disableProperties: ["animation"] }],
     },
+    // spread attributes should not throw an error (#49)
+    "<input {...inputProps} className={styles.input} onChange={handleChange}/>",
   ],
   invalid: [
     {


### PR DESCRIPTION
This pull request includes updates to two ESLint rules to improve attribute handling and adds new test cases to ensure proper functionality. The most important changes are:

Improvements to attribute handling:

* [`eslint-plugin/lib/rules/avoid-css-animations.js`](diffhunk://#diff-3fa85b9175dce5224c531d5c5b8e2f752c7f27d863b1df0c807169b10f3e138fL40-R40): Modified the attribute name check to use optional chaining to handle cases where `name` might be undefined.
* [`eslint-plugin/lib/rules/prefer-shorthand-css-notations.js`](diffhunk://#diff-2b147503cc87ed89a70761baee1526af4c4ecb9c2d647b06fa67681e78597fc3L87-R87): Modified the attribute name check to use optional chaining to handle cases where `name` might be undefined.

Fixes #49 