### PR TITLE
Fix eslint-plugin with SonarQube 25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ dependency-reduced-pom.xml
 
 # Auto-generated files
 coverage
-dist

--- a/eslint-plugin/.gitignore
+++ b/eslint-plugin/.gitignore
@@ -11,3 +11,4 @@ node_modules
 # Auto-generated files
 *-report.json
 .nyc_output
+dist/pack

--- a/eslint-plugin/dist/rules.js
+++ b/eslint-plugin/dist/rules.js
@@ -22,7 +22,7 @@
  */
 "use strict";
 
-const rules = require("./rule-list");
+const rules = require("../lib/rule-list");
 
 module.exports = {
   rules: rules.map((rule) => ({

--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -18,15 +18,16 @@
   "author": "Green Code Initiative",
   "main": "./lib/standalone.js",
   "files": [
-    "lib"
+    "lib",
+    "./dist/rules.js"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist/pack",
     "lint": "yarn lint:eslint-docs && yarn lint:js",
     "lint:eslint-docs": "eslint-doc-generator --check",
     "lint:js": "eslint .",
     "lint:fix": "eslint . --fix",
-    "pack:sonar": "npm pkg set main=\"./lib/sonar.js\" && mkdirp dist/pack && yarn pack -o dist/pack/creedengo-eslint-plugin.tgz && npm pkg set main=\"./lib/standalone.js\"",
+    "pack:sonar": "npm pkg set main=\"./dist/rules.js\" && mkdirp dist/pack && yarn pack -o dist/pack/creedengo-eslint-plugin.tgz && npm pkg set main=\"./lib/standalone.js\"",
     "test": "mocha tests --recursive",
     "test:cov": "nyc --reporter=lcov --reporter=text mocha tests --recursive",
     "update:eslint-docs": "eslint-doc-generator"

--- a/eslint-plugin/tests/dist/rules.test.js
+++ b/eslint-plugin/tests/dist/rules.test.js
@@ -18,9 +18,9 @@
 
 const assert = require("assert");
 
-describe("sonar.js", () => {
+describe("rules.js", () => {
   it("should export all rules with a specific rule id pattern", () => {
-    const { rules } = require("../../lib/sonar");
+    const { rules } = require("../../dist/rules");
     assert.notEqual(rules.length, 0);
     assert.match(rules[0].ruleId, /@creedengo\/.*/);
     assert.equal(rules[0].ruleConfig.length, 0);

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=green-code-initiative
 sonar.projectKey=green-code-initiative_ecoCode-linter
 sonar.projectName=creedengo - JavaScript language
-sonar.sources=eslint-plugin/lib/,sonar-plugin/src/main/java/
+sonar.sources=eslint-plugin/lib/,eslint-plugin/dist/rules.js,sonar-plugin/src/main/java/
 sonar.tests=eslint-plugin/tests/,sonar-plugin/src/test/java/
 sonar.javascript.lcov.reportPaths=eslint-plugin/coverage/lcov.info
 sonar.java.binaries=sonar-plugin/target/


### PR DESCRIPTION
This pull request includes updates to the `eslint-plugin` package to handle distribution files more effectively and adjust the packaging script to support **SonarQube 25+**. This version **NEEDS** to have a file called `dist/rules.js` in the package file.

File handling improvements:

* [`eslint-plugin/.gitignore`](diffhunk://#diff-95f3af8cfb45a067ac513928b8d2c6bc3d7a9b4c3d05bfb91b93fd4d13483e65R14): Added `dist/pack` to the `.gitignore` file to ignore the new distribution directory.

Packaging script adjustments:

* [`eslint-plugin/package.json`](diffhunk://#diff-1ce298b0628099e75c33e5f6a7b4416b8041d8860ca39f31a2be801cec9c2d0eL21-R30): Updated the `files` array to include `./dist/rules.js` and modified the `clean` script to remove `dist/pack` instead of `dist`. Additionally, the `pack:sonar` script was updated to set the main entry point to `./dist/rules.js` for packaging.