### PR TITLE
Show support for SonarQube 25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [#40](https://github.com/green-code-initiative/creedengo-javascript/pull/40) Add rule `@creedengo/avoid-autoplay` (GCI36)
 -   [#45](https://github.com/green-code-initiative/creedengo-javascript/pull/45) Add rule `@creedengo/avoid-keep-awake` (GCI505)
 -   [#46](https://github.com/green-code-initiative/creedengo-javascript/pull/46) Add rule `@creedengo/prefer-lighter-formats-for-image-files` (GCI31)
+-   [#68](https://github.com/green-code-initiative/creedengo-javascript/pull/68) Add support for SonarQube up to 25.3
 
 ## [2.0.0] - 2025-01-22
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The standalone version of the ESLint plugin is available from [npmjs](https://np
 
 | Plugins Version | SonarQube version | ESLint version |
 | --------------- | ----------------- | -------------- |
-| 2.+             | 9.9.+ LTA to 25.1 | 7+             |
+| 2.+             | 9.9.+ LTA to 25.3 | 7+             |
 | 1.4, 1.5        | 9.9.+ LTA to 10.7 | 7+             |
 
 ## 🤝 Contribution

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: sonarqube_creedengo_javascript
 
 services:
   sonar:
-    image: sonarqube:25.1.0.102122-community
+    image: sonarqube:25.3.0.104237-community
     container_name: sonar_creedengo_javascript
     ports:
       - "9000:9000"


### PR DESCRIPTION
### Updates for SonarQube support (up to 25.3):

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L6-R6): Updated the SonarQube image version from `25.1.0.102122-community` to `25.3.0.104237-community`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R51): Updated the supported SonarQube version range to include up to version `25.3`.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR15): Added an entry for the support of SonarQube up to version `25.3`.

Tests are OK locally ✅ 