### PR TITLE
Only support string literals in GCI11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [#46](https://github.com/green-code-initiative/creedengo-javascript/pull/46) Add rule `@creedengo/prefer-lighter-formats-for-image-files` (GCI31)
 -   [#68](https://github.com/green-code-initiative/creedengo-javascript/pull/68) Add support for SonarQube up to 25.3
 
+### Fixed
+
+-   [#69](https://github.com/green-code-initiative/creedengo-javascript/pull/69) Only support string literals in GCI11
+
 ## [2.0.0] - 2025-01-22
 
 ### Added

--- a/eslint-plugin/lib/rules/no-multiple-access-dom-element.js
+++ b/eslint-plugin/lib/rules/no-multiple-access-dom-element.js
@@ -48,7 +48,9 @@ module.exports = {
       CallExpression(node) {
         if (
           node.callee.object?.name === "document" &&
-          DOMAccessMethods.includes(node.callee.property.name)
+          DOMAccessMethods.includes(node.callee.property.name) &&
+          // We only accept string literals as arguments for now
+          node.arguments[0].type === "Literal"
         ) {
           const selectorValue = node.arguments[0].value;
           const uniqueCallStr = node.callee.property.name + selectorValue;

--- a/eslint-plugin/tests/lib/rules/no-multiple-access-dom-element.js
+++ b/eslint-plugin/tests/lib/rules/no-multiple-access-dom-element.js
@@ -49,6 +49,12 @@ ruleTester.run("no-multiple-access-dom-element", rule, {
     function test() { var link = document.getElementsByTagName('a'); }
     var link = document.getElementsByTagName('a');
     `,
+    `
+    for (var i = 0; i < 10; i++) {
+      var test = document.getElementsByName("test" + i)[0].value;
+      var test2 = document.getElementsByName("test2" + i)[0].value;
+    }
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
Updated the `@creedengo/no-multiple-access-dom-element` (**GCI11**) rule to only accept string literals as arguments.
Also added new test cases to verify the updated rule for handling string literals correctly.

We'll be able to add wider support for dynamic arguments in the future, but in the meantime it helps avoid false positives.

Fixes #59 