### PR TITLE
Avoid triggering an exception (GCI12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   [#69](https://github.com/green-code-initiative/creedengo-javascript/pull/69) Only support string literals (GCI11)
 -   [#70](https://github.com/green-code-initiative/creedengo-javascript/pull/70) Only support SQL queries within standard methods (GCI24)
+-   [#71](https://github.com/green-code-initiative/creedengo-javascript/pull/71) Avoid triggering an exception (GCI12)
 
 ## [2.0.0] - 2025-01-22
 

--- a/eslint-plugin/lib/rules/no-multiple-style-changes.js
+++ b/eslint-plugin/lib/rules/no-multiple-style-changes.js
@@ -34,9 +34,8 @@ module.exports = {
     schema: [],
   },
   create: function (context) {
-    function isNodeUseStyleProperty(node) {
-      return node?.object?.property?.name === "style";
-    }
+    const isNodeUseStyleProperty = (node) =>
+      node?.object?.property?.name === "style";
 
     return {
       AssignmentExpression(node) {
@@ -45,8 +44,10 @@ module.exports = {
           const domElementName = node.left.object.object.name;
           const currentRangestart = node.left.object.object.range[0];
 
-          /** We get the parent AST to check if there is more than one assignation on
-           the style of the same domElement */
+          /**
+           * Store parent AST to check if there is more
+           * than one assignation on the style of the same domElement
+           */
           const currentScopeASTBody =
             context.getScope().block.body.length != null
               ? context.getScope().block.body
@@ -62,10 +63,11 @@ module.exports = {
 
           // De-duplication, prevents multiple alerts for each line involved
           const isCurrentNodeTheFirstAssignation =
+            filtered.length > 1 &&
             currentRangestart <=
-            filtered[0].expression.left.object.object.range[0];
+              filtered[0].expression.left.object.object.range[0];
 
-          if (filtered.length > 1 && isCurrentNodeTheFirstAssignation) {
+          if (isCurrentNodeTheFirstAssignation) {
             context.report({
               node,
               messageId: "UseClassInstead",

--- a/eslint-plugin/tests/lib/rules/no-multiple-style-changes.js
+++ b/eslint-plugin/tests/lib/rules/no-multiple-style-changes.js
@@ -41,11 +41,14 @@ ruleTester.run("no-multiple-style-changes", rule, {
       code: 'element.style.height = "800px";',
     },
     {
-      code: `element.style.height = "800px";
-      element2.style.width = "800px";`,
+      code: `
+      element.style.height = "800px";
+      element2.style.width = "800px";
+      `,
     },
     {
-      code: `element.style.height = "800px";
+      code: `
+      element.style.height = "800px";
       function a() { element.style.width = "800px"; }
       `,
     },
@@ -53,15 +56,19 @@ ruleTester.run("no-multiple-style-changes", rule, {
 
   invalid: [
     {
-      code: `function a(element){
-          element.style.height = "800px";
-          element.style.width = "800px";
-        }`,
+      code: `
+      function a(element){
+        element.style.height = "800px";
+        element.style.width = "800px";
+      }
+      `,
       errors: [expectedError],
     },
     {
-      code: `element.style.height = "800px";
-      element.style.width = "800px";`,
+      code: `
+      element.style.height = "800px";
+      element.style.width = "800px";
+      `,
       errors: [expectedError],
     },
     {


### PR DESCRIPTION
This PR updates the rule `@creedengo/no-multiple-style-changes` (GCI12) to avoid triggering an exception when it executes on a specific piece of code without expression. This occurs when linting Next server code for example.

Fixes #66 