### PR TITLE
Avoid false-positive with nested objects in GCI12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [#69](https://github.com/green-code-initiative/creedengo-javascript/pull/69) Only support string literals (GCI11)
 -   [#70](https://github.com/green-code-initiative/creedengo-javascript/pull/70) Only support SQL queries within standard methods (GCI24)
 -   [#71](https://github.com/green-code-initiative/creedengo-javascript/pull/71) Avoid triggering an exception (GCI12)
+-   [#73](https://github.com/green-code-initiative/creedengo-javascript/pull/73) Avoid false-positive with nested objects (GCI12)
 
 ## [2.0.0] - 2025-01-22
 

--- a/eslint-plugin/tests/lib/rules/no-multiple-style-changes.js
+++ b/eslint-plugin/tests/lib/rules/no-multiple-style-changes.js
@@ -29,7 +29,12 @@ const RuleTester = require("eslint").RuleTester;
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2021,
+    sourceType: "module",
+  },
+});
 const expectedError = {
   messageId: "UseClassInstead",
   type: "AssignmentExpression",
@@ -52,6 +57,22 @@ ruleTester.run("no-multiple-style-changes", rule, {
       function a() { element.style.width = "800px"; }
       `,
     },
+    {
+      name: "should not report on different elements in same object",
+      code: `
+      var elements = { element1, element2 };
+      elements.element1.style.height = "800px";
+      elements.element2.style.height = "800px";
+      `,
+    },
+    {
+      code: `
+      var offsetWidth = 5;
+      var offsetLeft = 3;
+      element.style.width = \`\${offsetWidth}px\`;
+      element.style.left = \`\${offsetLeft}px\`;
+      `,
+    },
   ],
 
   invalid: [
@@ -68,6 +89,14 @@ ruleTester.run("no-multiple-style-changes", rule, {
       code: `
       element.style.height = "800px";
       element.style.width = "800px";
+      `,
+      errors: [expectedError],
+    },
+    {
+      code: `
+      var elements = { element1 };
+      elements.element1.style.height = "800px";
+      elements.element1.style.height = "800px";
       `,
       errors: [expectedError],
     },


### PR DESCRIPTION
This PR improves the rule `@creedengo/no-multiple-style-changes` (GCI12) to avoid false-positives about nested objects. It also exclude non-literals to avoid reports when values are dynamic.

Fixes #72 