### PR TITLE
Fix false positives caused by import checks in some rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#101](https://github.com/green-code-initiative/creedengo-javascript/pull/101) Fix spread style attributes in GCI26 and GCI29 rules
+- [#103](https://github.com/green-code-initiative/creedengo-javascript/pull/103) Fix false positives caused by import checks in GCI505, GCI522 and GCI523 rules
 
 ## [3.0.0] - 2026-02-03
 

--- a/eslint-plugin/lib/rules/avoid-brightness-override.js
+++ b/eslint-plugin/lib/rules/avoid-brightness-override.js
@@ -18,6 +18,8 @@
 
 "use strict";
 
+const { createDefaultImportsTracker } = require("../utils/import-tracker");
+
 const brightnessLibrariesMethods = {
   "expo-brightness": [
     "setBrightnessAsync",
@@ -45,30 +47,18 @@ module.exports = {
     schema: [],
   },
   create: function (context) {
-    const librariesFoundInImports = [];
+    const { importedObjects, ImportDeclaration } = createDefaultImportsTracker(
+      brightnessLibrariesMethods,
+    );
 
     return {
-      ImportDeclaration(node) {
-        const currentLibrary = node.source.value;
-
-        if (brightnessLibrariesMethods[currentLibrary]) {
-          librariesFoundInImports.push(currentLibrary);
-        }
-      },
+      ImportDeclaration,
       MemberExpression(node) {
-        if (librariesFoundInImports.length === 0) {
-          return;
-        }
+        if (importedObjects.size === 0) return;
 
-        if (
-          librariesFoundInImports.some((library) =>
-            brightnessLibrariesMethods[library].includes(node.property.name),
-          )
-        ) {
-          context.report({
-            node,
-            messageId: "ShouldAvoidOverrideBrightness",
-          });
+        const methods = importedObjects.get(node.object?.name);
+        if (methods?.includes(node.property.name)) {
+          context.report({ node, messageId: "ShouldAvoidOverrideBrightness" });
         }
       },
     };

--- a/eslint-plugin/lib/rules/avoid-high-accuracy-geolocation.js
+++ b/eslint-plugin/lib/rules/avoid-high-accuracy-geolocation.js
@@ -18,6 +18,8 @@
 
 "use strict";
 
+const { createDefaultImportsTracker } = require("../utils/import-tracker");
+
 const geolocationLibrariesMethods = {
   "expo-location": ["enableNetworkProviderAsync"],
 };
@@ -37,26 +39,17 @@ module.exports = {
     schema: [],
   },
   create: function (context) {
-    const librariesFoundInImports = [];
+    const { importedObjects, ImportDeclaration } = createDefaultImportsTracker(
+      geolocationLibrariesMethods,
+    );
 
     return {
-      ImportDeclaration(node) {
-        const currentLibrary = node.source.value;
-
-        if (geolocationLibrariesMethods[currentLibrary]) {
-          librariesFoundInImports.push(currentLibrary);
-        }
-      },
+      ImportDeclaration,
       MemberExpression(node) {
-        if (librariesFoundInImports.length === 0) {
-          return;
-        }
+        if (importedObjects.size === 0) return;
 
-        if (
-          librariesFoundInImports.some((library) =>
-            geolocationLibrariesMethods[library].includes(node.property.name),
-          )
-        ) {
+        const methods = importedObjects.get(node.object?.name);
+        if (methods?.includes(node.property.name)) {
           reportAvoidUsingAccurateGeolocation(context, node);
         }
       },

--- a/eslint-plugin/lib/rules/avoid-keep-awake.js
+++ b/eslint-plugin/lib/rules/avoid-keep-awake.js
@@ -37,26 +37,31 @@ module.exports = {
     schema: [],
   },
   create: function (context) {
-    const librariesFoundInImports = [];
+    // Maps the local identifier name to true when it was imported from a keep-awake library.
+    // Using local names handles aliased imports: import { activateKeepAwake as ka } from '…'
+    const importedMethods = new Set();
 
     return {
       ImportDeclaration(node) {
         const currentLibrary = node.source.value;
+        const methods = keepAwakeLibrariesMethods[currentLibrary];
 
-        if (keepAwakeLibrariesMethods[currentLibrary]) {
-          librariesFoundInImports.push(currentLibrary);
+        if (!methods) return;
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === "ImportSpecifier") {
+            const importedName = specifier.imported.name;
+            if (methods.includes(importedName)) {
+              // Track the local alias so renamed imports are also caught
+              importedMethods.add(specifier.local.name);
+            }
+          }
         }
       },
       CallExpression(node) {
-        if (librariesFoundInImports.length === 0) {
-          return;
-        }
+        if (importedMethods.size === 0) return;
 
-        if (
-          librariesFoundInImports.some((library) =>
-            keepAwakeLibrariesMethods[library].includes(node.callee.name),
-          )
-        ) {
+        if (importedMethods.has(node.callee.name)) {
           context.report({ node, messageId: "AvoidKeepAwake" });
         }
       },

--- a/eslint-plugin/lib/utils/import-tracker.js
+++ b/eslint-plugin/lib/utils/import-tracker.js
@@ -1,0 +1,54 @@
+/*
+ * creedengo JavaScript plugin - Provides rules to reduce the environmental footprint of your JavaScript programs
+ * Copyright © 2023 Green Code Initiative (https://green-code-initiative.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+/**
+ * Creates a shared import tracker used by rules that need to fire on
+ * `importedObj.method()` only when `importedObj` was actually imported
+ * from a known library.
+ *
+ * Returns the shared `importedObjects` map (localName → forbidden methods)
+ * and a ready-to-use `ImportDeclaration` AST visitor that populates it.
+ * Rules can spread the returned object directly into their visitor map.
+ *
+ * @param {Record<string, string[]>} libraryMethods
+ *   Map of library name → list of forbidden method names.
+ * @returns {{ importedObjects: Map<string, string[]>, ImportDeclaration: Function }}
+ */
+function createDefaultImportsTracker(libraryMethods) {
+  /** @type {Map<string, string[]>} */
+  const importedObjects = new Map();
+
+  function ImportDeclaration(node) {
+    const methods = libraryMethods[node.source.value];
+    if (!methods) return;
+
+    for (const specifier of node.specifiers) {
+      const localName = specifier.local.name;
+      if (!importedObjects.has(localName)) {
+        importedObjects.set(localName, []);
+      }
+      importedObjects.get(localName).push(...methods);
+    }
+  }
+
+  return { importedObjects, ImportDeclaration };
+}
+
+module.exports = { createDefaultImportsTracker };

--- a/eslint-plugin/tests/lib/rules/avoid-brightness-override.js
+++ b/eslint-plugin/tests/lib/rules/avoid-brightness-override.js
@@ -79,6 +79,22 @@ ruleTester.run("avoid-brightness-override", rule, {
         console.log('brightness', brightness);
         });
     `,
+    // False positive guard: a brightness library is imported but the flagged method is called
+    // on an unrelated object – it must NOT be reported.
+    `
+        import * as Brightness from 'expo-brightness';
+
+        const someOtherObj = {};
+        someOtherObj.setBrightnessAsync(0.5);
+    `,
+    // False positive guard: two brightness libraries are imported; calling a method belonging
+    // to library B on an object that was imported from library A must NOT be reported.
+    `
+        import * as Brightness from 'expo-brightness';
+        import DeviceBrightness from 'react-native-device-brightness';
+
+        Brightness.setBrightnessLevel(0.5);
+    `,
   ],
 
   invalid: [

--- a/eslint-plugin/tests/lib/rules/avoid-high-accuracy-geolocation.js
+++ b/eslint-plugin/tests/lib/rules/avoid-high-accuracy-geolocation.js
@@ -78,6 +78,14 @@ ruleTester.run("avoid-high-accuracy-geolocation", rule, {
     
     Location.requestPermissionsAsync();
     `,
+    // False positive guard: expo-location is imported but the flagged method is called on an
+    // unrelated object – it must NOT be reported.
+    `
+    import * as Location from 'expo-location';
+
+    const someOtherObj = {};
+    someOtherObj.enableNetworkProviderAsync();
+    `,
   ],
 
   invalid: [

--- a/eslint-plugin/tests/lib/rules/avoid-keep-awake.js
+++ b/eslint-plugin/tests/lib/rules/avoid-keep-awake.js
@@ -53,37 +53,50 @@ const expectedErrorFunction = {
 
 ruleTester.run("avoid-keep-awake", rule, {
   valid: [
-    {
-      code: `
-      import React from 'react';
-      import { Text, View } from 'react-native';
-      
-      export default function ValidExample() {
+    `
+    import React from 'react';
+    import { Text, View } from 'react-native';
+    
+    export default function ValidExample() {
+      return (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <Text>This screen will sleep!</Text>
+        </View>
+      );
+    }
+    `,
+    `
+    import React from 'react';
+    import { useKeepAwake } from 'other-library';
+    import { Button, View } from 'react-native';
+    
+    export default class ValidExample extends React.Component {
+      render() {
+        useKeepAwake();
         return (
-          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-            <Text>This screen will sleep!</Text>
-          </View>
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}></View>
         );
       }
-     `,
-    },
-    {
-      code: `
-      import React from 'react';
-      import { useKeepAwake } from 'other-library';
-      import { Button, View } from 'react-native';
-      
-      export default class ValidExample extends React.Component {
-        render() {
-          useKeepAwake();
-          return (
-            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-            </View>
-          );
-        }
-      }      
-     `,
-    },
+    }      
+    `,
+    // False positive guard: expo-keep-awake is imported for a side-effect but the
+    // function with the same name is defined locally – it must NOT be flagged.
+    `
+    import 'expo-keep-awake';
+
+    function activateKeepAwake() {
+      // local helper, unrelated to the library
+    }
+    activateKeepAwake();
+    `,
+    // False positive guard: a different export from expo-keep-awake is imported, while
+    // activateKeepAwake comes from another library – it must NOT be flagged.
+    `
+    import { deactivateKeepAwake } from 'expo-keep-awake';
+    import { activateKeepAwake } from 'some-other-library';
+
+    activateKeepAwake();
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
## Description

Rules that check imports to decide whether to flag a call or member expression were producing false positives in several scenarios. This PR fixes the underlying detection logic in three rules and adds test cases to cover those cases.

## Rules fixed

- `avoid-keep-awake` (GCI505)
- `avoid-brightness-override` (GCI522)
- `avoid-high-accuracy-geolocation` (GCI523)

## Checklist

- [x] My rule implementation covers the use case without false-positive
- [x] My code is explicit or well documented
- [x] I have provided unit tests
- [x] I have added a non-compliant example code inside the test project (existing files already cover these rules)
- [x] The coverage of my code is greater than 80% (99.64% statements, 91.32% branches)
- [x] I have modified the CHANGELOG with my change