### PR TITLE
29-js set sonarLintSupported to true

### DIFF
--- a/sonar-plugin/pom.xml
+++ b/sonar-plugin/pom.xml
@@ -136,7 +136,7 @@
                     <pluginKey>creedengojavascript</pluginKey>
                     <pluginName>${project.name}</pluginName>
                     <pluginClass>org.greencodeinitiative.creedengo.javascript.JavaScriptPlugin</pluginClass>
-                    <sonarLintSupported>false</sonarLintSupported>
+                    <sonarLintSupported>true</sonarLintSupported>
                     <pluginApiMinVersion>${version.sonarqube}</pluginApiMinVersion>
                     <skipDependenciesPackaging>true</skipDependenciesPackaging>
                     <jreMinVersion>${java.version}</jreMinVersion>


### PR DESCRIPTION
Unable to reproduce this issue. After investigation, the SonarQube plugin integration appears to be working correctly.
This issue may no longer be applicable.
So, _sonarLintSupported_ has been set to "true" to enable the SonarLint integration.